### PR TITLE
Adds support for passing decrypted key to OnSharedPreferenceChangeListen...

### DIFF
--- a/sample/src/com/securepreferences/sample/MainActivity.java
+++ b/sample/src/com/securepreferences/sample/MainActivity.java
@@ -19,6 +19,7 @@
 
 package com.securepreferences.sample;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
@@ -31,6 +32,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.text.method.LinkMovementMethod;
+import android.util.Log;
 import android.view.View;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -38,8 +40,7 @@ import android.widget.Toast;
 import com.securepreferences.SecurePreferences;
 
 public class MainActivity extends Activity {
-
-	private SecurePreferences mSecurePrefs;
+    private SecurePreferences mSecurePrefs;
 	private SharedPreferences mInSecurePrefs;
 
 	private TextView encValuesTextView;
@@ -65,6 +66,18 @@ public class MainActivity extends Activity {
 					}
 				});
 
+        // listen for specific keys and receive unencrypted key name on change
+        mSecurePrefs
+                .registerOnSharedPreferenceChangeListener(new OnSharedPreferenceChangeListener() {
+                    @Override
+                    public void onSharedPreferenceChanged(
+                            SharedPreferences sharedPreferences, String key) {
+                        Toast.makeText(MainActivity.this,
+                                "SecurePreference changed with key: " + key,
+                                Toast.LENGTH_SHORT).show();
+                    }
+                },
+                true);
 	}
 
 	private void initViews() {


### PR DESCRIPTION
When wanting to act on SharedPreferences changing I thought it would be useful to know which changed, so I've overloaded registerOnSharedPreferenceChangeListener() to add a flag which allows an OnSharedPreferenceChangeListener to receive the key that has changed decrypted (as there is no public access to decrypt()).
