### PR TITLE
Thread-safe for secure shared preferences

### DIFF
--- a/library/src/main/java/com/securepreferences/SecurePreferences.java
+++ b/library/src/main/java/com/securepreferences/SecurePreferences.java
@@ -176,7 +176,7 @@ public class SecurePreferences implements SharedPreferences {
                     .getDefaultSharedPreferences(context);
         }
         else{
-          return context.getSharedPreferences(prefFilename, Context.MODE_PRIVATE);
+          return context.getSharedPreferences(prefFilename, Context.MODE_MULTI_PROCESS | Context.MODE_PRIVATE);
         }
     }
 


### PR DESCRIPTION
The default shared preferences that comes with Android accept a flag called MODE_MULTI_PROCESS which makes the shared preferences thread-safe.

Here is the quote to the official documentation:
> SharedPreference loading flag: when set, the file on disk will be checked for modification even if the shared preferences instance is already loaded in this process. This behaviour is sometimes desired in cases where the application has multiple processes, all writing to the same SharedPreferences file. Generally there are better forms of communication between processes, though.

> This was the legacy (but undocumented) behaviour in and before Gingerbread (Android 2.3) and this flag is implied when targetting such releases. For applications targetting SDK versions greater than Android 2.3, this flag must be explicitly set if desired.

http://developer.android.com/reference/android/content/Context.html#MODE_MULTI_PROCESS