### PR TITLE
General Code Improvement 1

### DIFF
--- a/library/src/androidTest/java/com/securepreferences/test/TestSecurePreferences.java
+++ b/library/src/androidTest/java/com/securepreferences/test/TestSecurePreferences.java
@@ -355,8 +355,7 @@ public class TestSecurePreferences extends AndroidTestCase {
         String sharedPrefFolderPath = getContext().getFilesDir().getParent() + "/shared_prefs";
 
         String prefFilePath = sharedPrefFolderPath + "/" + prefFileName + ".xml";
-        File f = new File(prefFilePath);
-        return f;
+        return new File(prefFilePath);
     }
 
     private void deletePrefFile(String prefFileName) {

--- a/library/src/main/java/com/securepreferences/SecurePreferences.java
+++ b/library/src/main/java/com/securepreferences/SecurePreferences.java
@@ -507,7 +507,7 @@ public class SecurePreferences implements SharedPreferences {
 	 * original {@link SecurePreferences} until you call {@link #commit()} or
 	 * {@link #apply()}.
 	 */
-	public class Editor implements SharedPreferences.Editor {
+	public final class Editor implements SharedPreferences.Editor {
 		private SharedPreferences.Editor mEditor;
 
 		/**

--- a/library/src/main/java/com/securepreferences/SecurePreferencesOld.java
+++ b/library/src/main/java/com/securepreferences/SecurePreferencesOld.java
@@ -187,8 +187,7 @@ public class SecurePreferencesOld implements SharedPreferences {
 				algorthm, PROVIDER);
 		KeySpec keySpec = new PBEKeySpec(passphraseOrPin, salt, iterations,
 				keyLength);
-		SecretKey secretKey = secretKeyFactory.generateSecret(keySpec);
-		return secretKey;
+		return secretKeyFactory.generateSecret(keySpec);
 	}
 
 	/**
@@ -402,7 +401,7 @@ public class SecurePreferencesOld implements SharedPreferences {
 	 * original {@link SecurePreferencesOld} until you call {@link #commit()} or
 	 * {@link #apply()}.
 	 */
-	public static class Editor implements SharedPreferences.Editor {
+	public static final class Editor implements SharedPreferences.Editor {
 		private SharedPreferences.Editor mEditor;
 
 		/**

--- a/sample/src/com/securepreferences/sample/App.java
+++ b/sample/src/com/securepreferences/sample/App.java
@@ -54,8 +54,7 @@ public class App extends Application {
     public SharedPreferences getSharedPreferences1000() {
         try {
             AesCbcWithIntegrity.SecretKeys myKey = AesCbcWithIntegrity.generateKeyFromPassword(Build.SERIAL,AesCbcWithIntegrity.generateSalt(),1000);
-            SharedPreferences securePrefs1000 = new SecurePreferences(this, myKey, "my_prefs_1000.xml");
-            return securePrefs1000;
+            return new SecurePreferences(this, myKey, "my_prefs_1000.xml");
         } catch (GeneralSecurityException e) {
             Log.e(TAG, "Failed to create custom key for SecurePreferences", e);
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S2974 Classes without 'public' constructors should be 'final'
squid:S1488 Local Variables should not be declared and then immediately returned or thrown

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2974 
https://dev.eclipse.org/sonar/rules/show/squid:S1488 

Please let me know if you have any questions.

Zeeshan Asghar