### PR TITLE
General Code Improvement 3

### DIFF
--- a/library/src/androidTest/java/com/securepreferences/test/TestSecurePreferences.java
+++ b/library/src/androidTest/java/com/securepreferences/test/TestSecurePreferences.java
@@ -39,7 +39,7 @@ public class TestSecurePreferences extends AndroidTestCase {
         try {
             tearDown();
         } catch (Exception e) {
-            e.printStackTrace();
+            Log.d(TAG, "Exception in teamDown ", e);
         }
     }
 
@@ -268,7 +268,7 @@ public class TestSecurePreferences extends AndroidTestCase {
             assertEquals(DEFAULT_VALUE, retrievedValue);
 
         } catch (GeneralSecurityException e) {
-            e.printStackTrace();
+            Log.d(TAG, "GeneralSecurityException in testSupplyOwnKeys ", e);
             fail("Error generating a key");
         }
     }

--- a/library/src/main/java/com/securepreferences/SecurePreferences.java
+++ b/library/src/main/java/com/securepreferences/SecurePreferences.java
@@ -453,10 +453,10 @@ public class SecurePreferences implements SharedPreferences {
 
         Map<String, ?> allOfThePrefs = sharedPreferences.getAll();
         Map<String, String> unencryptedPrefs = new HashMap<String, String>(allOfThePrefs.size());
-        Iterator<String> keys = allOfThePrefs.keySet().iterator();
+        Iterator<String> keysIterator = allOfThePrefs.keySet().iterator();
         //iterate through the current prefs unencrypting each one
-        while(keys.hasNext()) {
-            String prefKey = keys.next();
+        while(keysIterator.hasNext()) {
+            String prefKey = keysIterator.next();
             Object prefValue = allOfThePrefs.get(prefKey);
             if(prefValue instanceof String){
                 //all the encrypted values will be Strings

--- a/library/src/main/java/com/securepreferences/SecurePreferencesOld.java
+++ b/library/src/main/java/com/securepreferences/SecurePreferencesOld.java
@@ -45,6 +45,7 @@ import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
 
 /**
+ * @deprecated
  * This is the old v.0.4.0 class only kept to help with migration in future versions.
  *
  * Wrapper class for Android's {@link android.content.SharedPreferences} interface, which adds a

--- a/sample/src/com/securepreferences/sample/MainActivity.java
+++ b/sample/src/com/securepreferences/sample/MainActivity.java
@@ -52,7 +52,7 @@ public class MainActivity extends ActionBarActivity {
 	private static final String KEY = "Foo";
 	private static final String VALUE = "Bar";
 
-    private static String GITHUB_LINK = "https://github.com/scottyab/secure-preferences";
+    private static String githubLink = "https://github.com/scottyab/secure-preferences";
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
@@ -177,7 +177,7 @@ public class MainActivity extends ActionBarActivity {
         int id = item.getItemId();
         if (id == R.id.action_github) {
             Intent i = new Intent(Intent.ACTION_VIEW);
-            i.setData(Uri.parse(GITHUB_LINK));
+            i.setData(Uri.parse(githubLink));
             startActivity(i);
             return true;
         }else if(id == R.id.action_create_user_prefs){


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:HiddenFieldCheck  Local variables should not shadow class fields
squid:MissingDeprecatedCheck  Deprecated elements should have both the annotation and the Javadoc tag
squid:S3008  Static non-final field names should comply with a naming convention
squid:S1148  Throwable.printStackTrace(...) should not be called

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:HiddenFieldCheck
https://dev.eclipse.org/sonar/rules/show/squid:MissingDeprecatedCheck
https://dev.eclipse.org/sonar/rules/show/squid:S3008
https://dev.eclipse.org/sonar/rules/show/squid:S1148

Please let me know if you have any questions.

Zeeshan Asghar