### PR TITLE
Expand method with iteration count, as mentioned in #18.

### DIFF
--- a/library/src/androidTest/java/com/securepreferences/test/TestSecurePreferences.java
+++ b/library/src/androidTest/java/com/securepreferences/test/TestSecurePreferences.java
@@ -215,7 +215,7 @@ public class TestSecurePreferences extends AndroidTestCase {
 		secureEdit.putUnencryptedString(key, value);
 		secureEdit.commit();
 
-		String retrievedValue = securePrefs.getUnencryptedString(key, null);
+		String retrievedValue = securePrefs.getEncryptedString(key, null);
 		assertEquals(value, retrievedValue);
 	}
 
@@ -305,14 +305,14 @@ public class TestSecurePreferences extends AndroidTestCase {
         editor.putString(key,value);
         editor.commit();
 
-        String cipherText = securePrefs.getUnencryptedString(key, null);
+        String cipherText = securePrefs.getEncryptedString(key, null);
         try {
             securePrefs.handlePasswordChange("newPassword", getContext());
         } catch (GeneralSecurityException e) {
             fail("error changing passwd: " + e.getMessage());
         }
 
-        String cipherTextFromNewPassword = securePrefs.getUnencryptedString(key, null);
+        String cipherTextFromNewPassword = securePrefs.getEncryptedString(key, null);
         String valueFromNewPassword = securePrefs.getString(key, null);
 
         assertNotNull("Cipher Text for key: " + key + " should not be null", cipherTextFromNewPassword);
@@ -329,14 +329,14 @@ public class TestSecurePreferences extends AndroidTestCase {
         editor.putString(key,value);
         editor.commit();
 
-        String cipherText = securePrefs.getUnencryptedString(key, null);
+        String cipherText = securePrefs.getEncryptedString(key, null);
         try {
             securePrefs.handlePasswordChange("myfirstpassword", getContext(), 1000);
         } catch (GeneralSecurityException e) {
             fail("error changing passwd: " + e.getMessage());
         }
 
-        String cipherTextFromPasswordChangedIteration = securePrefs.getUnencryptedString(key, null);
+        String cipherTextFromPasswordChangedIteration = securePrefs.getEncryptedString(key, null);
         String valueFromPasswordChangedIteration = securePrefs.getString(key, null);
 
         assertNotNull("Cipher Text for key: " + key + " should not be null", cipherTextFromPasswordChangedIteration);

--- a/library/src/androidTest/java/com/securepreferences/test/TestSecurePreferences.java
+++ b/library/src/androidTest/java/com/securepreferences/test/TestSecurePreferences.java
@@ -320,6 +320,30 @@ public class TestSecurePreferences extends AndroidTestCase {
         assertEquals(value, valueFromNewPassword);
     }
 
+
+    public void testChangeIterationCount() {
+        SecurePreferences securePrefs = new SecurePreferences(getContext(), "myfirstpassword", USER_PREFS_WITH_PASSWORD);
+        Editor editor = securePrefs.edit();
+        final String key = "pwchgfoo";
+        final String value = "pwchgbar";
+        editor.putString(key,value);
+        editor.commit();
+
+        String cipherText = securePrefs.getUnencryptedString(key, null);
+        try {
+            securePrefs.handlePasswordChange("myfirstpassword", getContext(), 1000);
+        } catch (GeneralSecurityException e) {
+            fail("error changing passwd: " + e.getMessage());
+        }
+
+        String cipherTextFromPasswordChangedIteration = securePrefs.getUnencryptedString(key, null);
+        String valueFromPasswordChangedIteration = securePrefs.getString(key, null);
+
+        assertNotNull("Cipher Text for key: " + key + " should not be null", cipherTextFromPasswordChangedIteration);
+        assertNotSame("The two cipher texts should not be the same", cipherText, cipherTextFromPasswordChangedIteration);
+        assertEquals(value, valueFromPasswordChangedIteration);
+    }
+
     /**
      * Load the pref xml file and read through to see if it has any <string tags.
      * @param prefFileName

--- a/library/src/main/java/com/securepreferences/SecurePreferences.java
+++ b/library/src/main/java/com/securepreferences/SecurePreferences.java
@@ -84,6 +84,17 @@ public class SecurePreferences implements SharedPreferences {
         this(context, "", null);
     }
 
+
+	/**
+	 *
+	 * @param context should be ApplicationContext not Activity
+	 * @param iterationCount The iteration count for the keys generation
+     */
+	public SecurePreferences(Context context, int iterationCount) {
+		this(context, "", null, iterationCount);
+	}
+
+
     /**
      *
      * @param context should be ApplicationContext not Activity
@@ -95,6 +106,16 @@ public class SecurePreferences implements SharedPreferences {
     }
 
 
+	/**
+	 *
+	 * @param context should be ApplicationContext not Activity
+	 * @param iterationCount The iteration count for the keys generation
+	 */
+	public SecurePreferences(Context context, final String password, final String sharedPrefFilename, int iterationCount) {
+		this(context, null, password, sharedPrefFilename, iterationCount);
+	}
+
+
     /**
      *
      *
@@ -103,7 +124,7 @@ public class SecurePreferences implements SharedPreferences {
      * @param sharedPrefFilename name of the shared pref file. If null use the default shared prefs
      */
     public SecurePreferences(Context context, final AesCbcWithIntegrity.SecretKeys secretKey, final String sharedPrefFilename) {
-        this(context, secretKey, null, sharedPrefFilename, ORIGINAL_ITERATION_COUNT);
+        this(context, secretKey, null, sharedPrefFilename, 0);
     }
 
     private SecurePreferences(Context context, final AesCbcWithIntegrity.SecretKeys secretKey, final String password, final String sharedPrefFilename, int iterationCount) {
@@ -145,9 +166,9 @@ public class SecurePreferences implements SharedPreferences {
             //use the password to generate the key
             try {
                 final byte[] salt = getDeviceSerialNumber(context).getBytes();
-                keys = AesCbcWithIntegrity.generateKeyFromPassword(password, salt);
+                keys = AesCbcWithIntegrity.generateKeyFromPassword(password, salt, iterationCount);
 
-                if(keys ==null){
+                if(keys == null){
                     throw new GeneralSecurityException("Problem generating Key From Password");
                 }
             } catch (GeneralSecurityException e) {

--- a/library/src/main/java/com/securepreferences/SecurePreferences.java
+++ b/library/src/main/java/com/securepreferences/SecurePreferences.java
@@ -189,7 +189,7 @@ public class SecurePreferences implements SharedPreferences {
 
     /**
      * if a prefFilename is not defined the getDefaultSharedPreferences is used.
-     * @param context
+	 * @param context should be ApplicationContext not Activity
      * @return
      */
     private SharedPreferences getSharedPreferenceFile(Context context, String prefFilename) {
@@ -214,8 +214,8 @@ public class SecurePreferences implements SharedPreferences {
 
     /**
      * Uses device and application values to generate the pref key for the encryption key
-     * @param context
-     * @param iterationCount
+	 * @param context should be ApplicationContext not Activity
+	 * @param iterationCount The iteration count for the keys generation
 	 * @return String to be used as the AESkey Pref key
      * @throws GeneralSecurityException if something goes wrong in generation
      */
@@ -228,6 +228,13 @@ public class SecurePreferences implements SharedPreferences {
 		return hashPrefKey(generatedKeyName.toString());
 	}
 
+
+	/**
+	 * Uses device and application values to generate the pref key for the encryption key
+	 * @param context should be ApplicationContext not Activity
+	 * @return String to be used as the AESkey Pref key
+	 * @throws GeneralSecurityException if something goes wrong in generation
+	 */
 	public String generateAesKeyName(Context context) throws GeneralSecurityException {
 		return generateAesKeyName(context, ORIGINAL_ITERATION_COUNT);
 	}
@@ -320,16 +327,12 @@ public class SecurePreferences implements SharedPreferences {
             AesCbcWithIntegrity.CipherTextIvMac cipherTextIvMac = new AesCbcWithIntegrity.CipherTextIvMac(ciphertext);
 
             return AesCbcWithIntegrity.decryptString(cipherTextIvMac, keys);
-        } catch (GeneralSecurityException e) {
-            if (sLoggingEnabled) {
-                Log.w(TAG, "decrypt", e);
-            }
-        } catch (UnsupportedEncodingException e) {
+        } catch (GeneralSecurityException | UnsupportedEncodingException e) {
             if (sLoggingEnabled) {
                 Log.w(TAG, "decrypt", e);
             }
         }
-        return null;
+		return null;
     }
 
     /**
@@ -470,11 +473,13 @@ public class SecurePreferences implements SharedPreferences {
      * Note: the pref keys will remain the same as they are SHA256 hashes.
      *
      * @param newPassword
+	 * @param context should be ApplicationContext not Activity
+	 * @param iterationCount The iteration count for the keys generation
      */
     public void handlePasswordChange(String newPassword, Context context, int iterationCount) throws GeneralSecurityException {
 
         final byte[] salt = getDeviceSerialNumber(context).getBytes();
-        AesCbcWithIntegrity.SecretKeys newKey= AesCbcWithIntegrity.generateKeyFromPassword(newPassword,salt, iterationCount);
+        AesCbcWithIntegrity.SecretKeys newKey= AesCbcWithIntegrity.generateKeyFromPassword(newPassword, salt, iterationCount);
 
         Map<String, ?> allOfThePrefs = sharedPreferences.getAll();
         Map<String, String> unencryptedPrefs = new HashMap<String, String>(allOfThePrefs.size());

--- a/library/src/main/java/com/securepreferences/SecurePreferences.java
+++ b/library/src/main/java/com/securepreferences/SecurePreferences.java
@@ -172,7 +172,7 @@ public class SecurePreferences implements SharedPreferences {
      * @return
      */
     private SharedPreferences getSharedPreferenceFile(Context context, String prefFilename) {
-        this.sharedPrefFilename = sharedPrefFilename;
+        this.sharedPrefFilename = prefFilename;
 
         if(TextUtils.isEmpty(prefFilename)) {
             return PreferenceManager

--- a/library/src/main/java/com/securepreferences/SecurePreferences.java
+++ b/library/src/main/java/com/securepreferences/SecurePreferences.java
@@ -380,12 +380,12 @@ public class SecurePreferences implements SharedPreferences {
 	 * 
 	 * @param key
 	 * @param defaultValue
-	 * @return Unencrypted value of the key or the defaultValue if
+	 * @return Encrypted value of the key or the defaultValue if
 	 */
-	public String getUnencryptedString(String key, String defaultValue) {
-		final String nonEncryptedValue = sharedPreferences.getString(
+	public String getEncryptedString(String key, String defaultValue) {
+		final String encryptedValue = sharedPreferences.getString(
 				SecurePreferences.hashPrefKey(key), null);
-		return (nonEncryptedValue != null) ? nonEncryptedValue : defaultValue;
+		return (encryptedValue != null) ? encryptedValue : defaultValue;
 	}
 
 	@Override


### PR DESCRIPTION
Hello there, 

As mentioned in #18, default constructor of SecurePreference is too slow to create instance. In there, solution is to give parameter at `AesCbcWithIntegrity.generateKeyFromPassword(...)` like below.

```
AesCbcWithIntegrity.SecretKeys mykeys = AesCbcWithIntegrity.generateKeyFromPassword(password, salt, iterationCount);
SecurePreferences securePrefs = new SecurePreferences(getContext(), mykeys, "pref-file");
```

But if **already use this library**, we need to change password using `handlePasswordChange(String newPassword, Context context)` **to solve the problem too slow to create instance**. This method doesn't support not only iteration count to generate key, but also AES key.

If I solve above problem, next is to check is this migrated. Then if password changed with iteration, I make instance of SecurePreference. But also, there is blocker `generateAesKeyName` in constructor when pass password, not key. `generateAesKeyName` is default key generator of key, also don't support iteration count to generate key. But this method is **private static**. I can't override it. So inheritance of SecurePreference can't solve problem.

## So What I did :

1. Expand method `constructor, handlePasswordChange, generateAesKeyName` with iterationCount

2. Make public `generateAesKeyName` for to prepare something to change logic
(Maybe, protected is enough to cover this issue.)

3. Add comment

4. Add test to `handlePasswordChange` with iteration count

5. Fix wrong method name. `getUnencryptedString` -> `getEncryptedString` 
(Value from sharePreference look like not encrypted, but not using original key, using hashPrefKey in this method)

6. Fix wrong assignment to sharePrefFilename (Same with #42)

Thanks for reading. If you have any question or request, please let me know.