### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ The sample app is available on [playstore](https://play.google.com/store/apps/de
 <img src="https://raw.github.com/scottyab/secure-preferences/master/docs/images/ss_frame_secure_pref.png" height="400" alt="Sample app Screenshot" />
  
 
-##Release v0.1.0+
+## Release v0.1.0+
 The **v0.1.0** release was a major refactor of the guts of secure prefs, which is *Not backwards compatible* yet with older 0.0.1 - 0.0.4 versions. So if you have an existing app using this don't upgrade. I'll be looking to add migration into a later release.
 
 [Full list of changes](changes.md)
 
-#Usage
+# Usage
 
-##Dependency
+## Dependency
 
 Maven central is the preferred way:
 
@@ -30,7 +30,7 @@ dependencies {
 }
 ```
 
-###Download
+### Download
 Or download the release .aar or clone this repo and add the library as a Android library project/module.
 
 ### ProGuard config
@@ -48,14 +48,14 @@ If you are using version v0.1.0 - v0.1.2 please use the below (thanks to @cermak
 There is specific DexGuard config supplied with DexGuard 7+ located `<dexgaurd root>/samples/advanced/SecurePreferences`
 
 
-#Examples
+# Examples
 This will use the default shared pref file
 
 ```java
 SharedPreferences prefs = new SecurePreferences(context);     
 ```
 
-##Custom pref file
+## Custom pref file
 You can define a separate file for encrypted preferences. 
 
 ```java
@@ -63,14 +63,14 @@ SharedPreferences prefs = new SecurePreferences(context, null, "my_custom_prefs.
 ```
 
 
-##User password - (recommended)
+## User password - (recommended)
 Using a password that the user types in that isn't stored elsewhere in the app passed to the SecurePreferences constructor means the key is generated at runtime and *not* stored in the backing pref file.
 
 ```java
 SharedPreferences prefs = new SecurePreferences(context, "userpassword", "my_user_prefs.xml");
 ```
 
-##Changing Password
+## Changing Password
 
 ```java
 SecurePreferences securePrefs = new SecurePreferences(context, "userpassword", "my_user_prefs.xml");
@@ -78,11 +78,11 @@ securePrefs.handlePasswordChange("newPassword", context);
 ```
 
 
-#What does the data look like?
+# What does the data look like?
 
 SharedPreferences keys and values are stored as simple map in an XML file.  You could also use a rooted device and an app like [cheatdroid](https://play.google.com/store/apps/details?id=com.felixheller.sharedprefseditor&hl=en_GB)
 
-##XML using Standard Android SharedPreferences
+## XML using Standard Android SharedPreferences
 
 
 ```xml
@@ -92,7 +92,7 @@ SharedPreferences keys and values are stored as simple map in an XML file.  You 
 </map>
 ```
 
-##XML with SecurePreferences
+## XML with SecurePreferences
 
 
 ```xml
@@ -107,16 +107,16 @@ SharedPreferences keys and values are stored as simple map in an XML file.  You 
 ```
 
 
-###Disclaimer
+### Disclaimer
 By default it's not bullet proof security (in fact it's more like obfuscation of the preferences) but it's a quick win for incrementally making your android app more secure. For instance it'll stop users on rooted devices easily modifying your app's shared prefs.
 *Recommend using the user password based prefs as introduced in v0.1.0.*
 
 
-###Contributing 
+### Contributing 
 Please do send me pull requests, but also bugs, issues and enhancement requests are welcome please add an issue.
 
 
-###Licence 
+### Licence 
 
 Much of the original code is from Daniel Abraham article on [codeproject](http://www.codeproject.com/Articles/549119/Encryption-Wrapper-for-Android-SharedPreferences). This project was created and shared on Github with his permission. 
 


### PR DESCRIPTION
Looks like they decided to change the way they parse markdown so now titles have to have a whitespace between the `#` symbol and the text ¯\\\_(ツ)_/¯