### PR TITLE
Ensure we always return a String in getString

### DIFF
--- a/library/src/main/java/com/securepreferences/SecurePreferences.java
+++ b/library/src/main/java/com/securepreferences/SecurePreferences.java
@@ -335,7 +335,13 @@ public class SecurePreferences implements SharedPreferences {
     public String getString(String key, String defaultValue) {
         final String encryptedValue = sharedPreferences.getString(
                 SecurePreferences.hashPrefKey(key), null);
-        return (encryptedValue != null) ? decrypt(encryptedValue) : defaultValue;
+
+        String decryptedValue = decrypt(encryptedValue);
+        if (encryptedValue != null && decryptedValue != null) {
+            return decryptedValue;
+        } else {
+            return defaultValue;
+        }
     }
 
     /**


### PR DESCRIPTION
There's some corner cases where getString may return a `null` value even when the `defaultValue` is a String. While I could not reproduce this behaviour, this is a known issue (#38) and _possible_ in the code, as `decrypt` may return a `null` value in certain situations.