### PR TITLE
Added constructor that allows user to choose their own salt.

### DIFF
--- a/library/src/main/java/com/securepreferences/SecurePreferences.java
+++ b/library/src/main/java/com/securepreferences/SecurePreferences.java
@@ -82,6 +82,13 @@ public class SecurePreferences implements SharedPreferences {
         this(context, "", null);
     }
 
+    /**
+     * @param context should be ApplicationContext not Activity
+     * @param salt is custom salt you choose for encryption
+     */
+    public SecurePreferences(Context context, String salt) {
+        this(context, null, "", salt, null, ORIGINAL_ITERATION_COUNT);
+    }
 
     /**
      * @param context        should be ApplicationContext not Activity


### PR DESCRIPTION
- This is to a work-around for the crash caused by Build.class.getField("SERIAL") returning "UNKNOWN" when users upgrade to Android Pie